### PR TITLE
Deprecated get_settings() replaced by get_option()

### DIFF
--- a/sketchfab-viewer.php
+++ b/sketchfab-viewer.php
@@ -19,23 +19,23 @@ License: A "Slug" license name e.g. GPL2
   // [sketchfab id=xxx ]
   function addSketchfab($atts, $content = null) {
     extract(shortcode_atts(array( "id" => '',
-                                "start" => get_settings('sketchfab-autostart'),
-                                "spin" => get_settings('sketchfab-autospin'),
-                                "controls" => get_settings('sketchfab-controls'),
-                                "transparent" => get_settings('sketchfab-transparent'),
-                                "width" => get_settings('sketchfab-width'),
-                                "height" => get_settings('sketchfab-height'),
+                                "start" => get_option('sketchfab-autostart'),
+                                "spin" => get_option('sketchfab-autospin'),
+                                "controls" => get_option('sketchfab-controls'),
+                                "transparent" => get_option('sketchfab-transparent'),
+                                "width" => get_option('sketchfab-width'),
+                                "height" => get_option('sketchfab-height'),
                           ), $atts));
     return '<iframe frameborder="0" height="'.$height.'" width="'.$width.'" webkitallowfullscreen="true" mozallowfullscreen="true" src="https://sketchfab.com/models/'.$id.'/embed?autostart='.$start.'&autospin='.$spin.'&controls='.$controls.'&transparent='.$transparent.'"></iframe>';
   }
   add_shortcode('sketchfab', 'addSketchfab');
 
   // Add Sketchfab button to MCE
-  
+
   function add_sketchfab_button() {
     if( ! current_user_can('edit_posts') && ! current_user_can('edit_pages') )
       return;
-    
+
     if( get_user_option('rich_editing') == 'true') {
       add_filter('mce_external_plugins', 'add_sketchfab_tinymce_plugin');
       add_filter('mce_buttons', 'register_sketchfab_button');
@@ -67,7 +67,7 @@ License: A "Slug" license name e.g. GPL2
     // Create top-level menu
     add_menu_page('Sketchfab Plugin Settings', 'Sketchfab', 'administrator',
       __FILE__, 'sketchfab_settings_page', plugins_url('/img/sketchfab-menu-icon.png', __FILE__));
-  
+
     // Call register settings function
     add_action( 'admin_init', 'register_settings' );
   }
@@ -89,7 +89,7 @@ License: A "Slug" license name e.g. GPL2
 
   <form method="post" action="options.php">
     <?php settings_fields( 'settings-group' ); ?>
-    
+
     <h3>Default settings</h3>
     <table class="form-table">
       <tr valign="top">
@@ -117,9 +117,9 @@ License: A "Slug" license name e.g. GPL2
         <td><input type="checkbox" name="sketchfab-transparent" value="1" <?php checked(get_option('sketchfab-transparent'), 1); ?>/></td>
       </tr>
     </table>
-    
+
     <?php submit_button(); ?>
-  </form> 
+  </form>
 </div>
 
 <?php } ?>


### PR DESCRIPTION
Hi,

Since Wordpress 2.1, get_settings() is deprecated. It apperas when WP_DEBUG is turned true.

So i replace by get_option(). All works fine.
